### PR TITLE
[fix] Use new label for knative broker (needed for Serverless 1.11.0)

### DIFF
--- a/test/yaks-config.yaml
+++ b/test/yaks-config.yaml
@@ -11,7 +11,7 @@ pre:
     ## Install Knative Broker
     # TODO: replace with following when updating CI
     # kn broker create default -n ${YAKS_NAMESPACE}
-    oc label namespace ${YAKS_NAMESPACE} knative-eventing-injection=enabled
+    oc label namespace ${YAKS_NAMESPACE} eventing.knative.dev/injection=enabled
     
     ## Mock generator
     kamel run test/MarketSourceMock.java -w -n ${YAKS_NAMESPACE}


### PR DESCRIPTION
As described at https://docs.openshift.com/container-platform/4.6/serverless/event_workflows/serverless-using-brokers.html#serverless-using-brokers-creating-brokers